### PR TITLE
Fix GitHub link to iraddev profile

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -24,7 +24,7 @@ const today = new Date();
       <Icon name="mdi:linkedin" width="32" height="32" />
     </a>
     <a
-      href="https://github.com/irad100"
+      href="https://github.com/iraddev"
       target="_blank"
       class="text-slate-500 hover:text-slate-800"
     >

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -48,7 +48,7 @@ import logo from "../assets/logo.png";
         <Icon name="mdi:linkedin" width="32" height="32" />
       </a>
       <a
-        href="https://github.com/irad100"
+        href="https://github.com/iraddev"
         target="_blank"
         class="flex border-b-4 border-transparent px-2 py-4 text-black no-underline"
       >


### PR DESCRIPTION
Updates the GitHub profile link in the header and footer from `github.com/irad100` to `github.com/iraddev`.

## Changes
- `src/components/Header.astro` — GitHub icon link
- `src/components/Footer.astro` — GitHub icon link